### PR TITLE
Update dashboard homepage

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,21 +1,16 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
-  "stories": [
-    "../src/**/*.mdx",
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    '@chromatic-com/storybook',
+    '@storybook/addon-docs',
+    '@storybook/addon-onboarding',
+    '@storybook/addon-a11y',
   ],
-  "addons": [
-    "@chromatic-com/storybook",
-    "@storybook/addon-docs",
-    "@storybook/addon-onboarding",
-    "@storybook/addon-a11y",
-    "@storybook/addon-vitest",
-    'storybook-dark-mode',
-  ],
-  "framework": {
-    "name": "@storybook/react-vite",
-    "options": {}
-  }
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
 };
 export default config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "vitest",
+    "test": "vitest --project=unit",
+    "test:storybook": "vitest --project=storybook",
+    "test:all": "vitest",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -13,15 +15,17 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@mantine/core": "^8.3.12",
-    "@mantine/hooks": "^8.3.12",
+    "@mantine/charts": "^9.1.0",
+    "@mantine/core": "^9.1.0",
+    "@mantine/hooks": "^9.1.0",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-query-devtools": "^5.91.2",
     "axios": "^1.11.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-hook-form": "^7.71.1",
-    "react-router-dom": "^7.8.1"
+    "react-router-dom": "^7.8.1",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.1",

--- a/frontend/src/assets/graph.svg
+++ b/frontend/src/assets/graph.svg
@@ -1,0 +1,10 @@
+<svg width="80" height="40" viewBox="0 0 80 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_901_108)">
+<path d="M0 31.9998C5.33333 18.6665 10.6667 15.9998 16 23.9998C21.3333 31.9998 26.6667 29.3331 32 15.9998C37.3333 2.66646 42.6667 6.66646 48 27.9998C53.3333 49.3331 58.6667 42.6665 64 7.9998C69.3333 -26.6669 74.6667 -22.6669 80 19.9998" stroke="#1C2ECC" stroke-width="1.6"/>
+</g>
+<defs>
+<clipPath id="clip0_901_108">
+<rect width="80" height="40" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/frontend/src/components/Forms/FilterAndSortForm/FilterAndSortForm.test.tsx
+++ b/frontend/src/components/Forms/FilterAndSortForm/FilterAndSortForm.test.tsx
@@ -6,11 +6,12 @@ import * as useUrlFiltersModule from '@/hooks/useUrlFilters/useUrlFilters';
 
 describe('FilterAndSortForm', () => {
   const filterItems = ['Name', 'Location', 'Status'];
+  const mockOnClose = vi.fn();
 
   test('renders filter inputs based on filterItems prop', () => {
     render(
       <MemoryRouter>
-        <FilterAndSortForm filterItems={filterItems} />
+        <FilterAndSortForm filterItems={filterItems} onSubmit={mockOnClose} />
       </MemoryRouter>,
     );
 
@@ -23,7 +24,7 @@ describe('FilterAndSortForm', () => {
   test('renders sort by select with correct options', () => {
     render(
       <MemoryRouter>
-        <FilterAndSortForm filterItems={filterItems} />
+        <FilterAndSortForm filterItems={filterItems} onSubmit={mockOnClose} />
       </MemoryRouter>,
     );
 
@@ -47,7 +48,7 @@ describe('FilterAndSortForm', () => {
 
     render(
       <MemoryRouter>
-        <FilterAndSortForm filterItems={filterItems} />
+        <FilterAndSortForm filterItems={filterItems} onSubmit={mockOnClose} />
       </MemoryRouter>,
     );
 
@@ -73,5 +74,6 @@ describe('FilterAndSortForm', () => {
       sort: 'branchEmail',
       order: 'asc',
     });
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/Forms/FilterAndSortForm/FilterAndSortForm.test.tsx
+++ b/frontend/src/components/Forms/FilterAndSortForm/FilterAndSortForm.test.tsx
@@ -8,7 +8,7 @@ describe('FilterAndSortForm', () => {
   const filterItems = ['Name', 'Location', 'Status'];
   const mockOnClose = vi.fn();
 
-  test('renders filter inputs based on filterItems prop', () => {
+  it('renders filter inputs based on filterItems prop', () => {
     render(
       <MemoryRouter>
         <FilterAndSortForm filterItems={filterItems} onSubmit={mockOnClose} />
@@ -21,23 +21,27 @@ describe('FilterAndSortForm', () => {
     });
   });
 
-  test('renders sort by select with correct options', () => {
+  it('renders sort by select with correct options', () => {
+    const options = ['A-Z', 'Z-A', 'Newest', 'Oldest'];
     render(
       <MemoryRouter>
-        <FilterAndSortForm filterItems={filterItems} onSubmit={mockOnClose} />
+        <FilterAndSortForm
+          filterItems={filterItems}
+          onSubmit={mockOnClose}
+          sortItems={options}
+        />
       </MemoryRouter>,
     );
 
     const sortBySelect = screen.getByLabelText('Sort By');
     expect(sortBySelect).toBeInTheDocument();
 
-    const options = ['A-Z', 'Z-A', 'Newest', 'Oldest'];
     options.forEach((option) => {
       expect(screen.getByRole('option', { name: option })).toBeInTheDocument();
     });
   });
 
-  test('submits form and calls updateMultipleFilters with correct values', async () => {
+  it('submits form and calls updateMultipleFilters with correct values', async () => {
     const mockUpdateMultipleFilters = vi.fn();
 
     vi.spyOn(useUrlFiltersModule, 'useUrlFilters').mockReturnValue({
@@ -48,7 +52,15 @@ describe('FilterAndSortForm', () => {
 
     render(
       <MemoryRouter>
-        <FilterAndSortForm filterItems={filterItems} onSubmit={mockOnClose} />
+        <FilterAndSortForm
+          filterItems={filterItems}
+          onSubmit={mockOnClose}
+          sortItems={['Email', 'Status']}
+          orderItems={[
+            { label: 'A-Z', value: 'asc' },
+            { label: 'Z-A', value: 'desc' },
+          ]}
+        />
       </MemoryRouter>,
     );
 
@@ -71,7 +83,7 @@ describe('FilterAndSortForm', () => {
       name: 'Test Name',
       location: 'Test Location',
       status: 'Active',
-      sort: 'branchEmail',
+      sort: 'email',
       order: 'asc',
     });
     expect(mockOnClose).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/Forms/FilterAndSortForm/FilterAndSortForm.tsx
+++ b/frontend/src/components/Forms/FilterAndSortForm/FilterAndSortForm.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 interface FilterAndSortFormProps {
   filterItems: string[];
+  onSubmit?: () => void;
 }
 
 const sortMenuItems = [
@@ -16,7 +17,10 @@ const sortMenuItems = [
   { label: 'Oldest', value: 'oldest' },
 ];
 
-export const FilterAndSortForm = ({ filterItems }: FilterAndSortFormProps) => {
+export const FilterAndSortForm = ({
+  filterItems,
+  onSubmit,
+}: FilterAndSortFormProps) => {
   const { searchParams, updateMultipleFilters } = useUrlFilters();
 
   const currentParams: Record<string, string> = Object.fromEntries(
@@ -31,6 +35,7 @@ export const FilterAndSortForm = ({ filterItems }: FilterAndSortFormProps) => {
       filters[toCamelCase(key)] = value.toString();
     });
     updateMultipleFilters(filters);
+    onSubmit?.();
   };
 
   return (

--- a/frontend/src/components/Forms/FilterAndSortForm/FilterAndSortForm.tsx
+++ b/frontend/src/components/Forms/FilterAndSortForm/FilterAndSortForm.tsx
@@ -8,18 +8,16 @@ import React from 'react';
 interface FilterAndSortFormProps {
   filterItems: string[];
   onSubmit?: () => void;
+  sortItems?: string[];
+  orderItems?: { label: string; value: string }[];
 }
 
-const sortMenuItems = [
-  { label: 'A-Z', value: 'asc' },
-  { label: 'Z-A', value: 'desc' },
-  { label: 'Newest', value: 'newest' },
-  { label: 'Oldest', value: 'oldest' },
-];
 
 export const FilterAndSortForm = ({
   filterItems,
   onSubmit,
+  sortItems,
+  orderItems,
 }: FilterAndSortFormProps) => {
   const { searchParams, updateMultipleFilters } = useUrlFilters();
 

--- a/frontend/src/components/Layout/Header/Header.stories.tsx
+++ b/frontend/src/components/Layout/Header/Header.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Header } from '../Header';
+import { Header } from '.';
+import { MemoryRouter } from 'react-router-dom';
 
 type Story = StoryObj<typeof meta>;
 
@@ -8,6 +9,11 @@ const meta = {
   title: 'Header',
   component: Header,
   tags: ['autodocs'],
+  render: () => (
+    <MemoryRouter>
+      <Header />
+    </MemoryRouter>
+  ),
 } satisfies Meta<typeof Header>;
 
 export default meta;

--- a/frontend/src/components/Layout/Header/Header.tsx
+++ b/frontend/src/components/Layout/Header/Header.tsx
@@ -1,12 +1,17 @@
-import React from 'react';
+import { Sidebar } from '@/components/Sidebar';
 
 export const Header = () => {
   return (
     <div className="flex border-b border-gray-300 bg-white justify-center">
       <div className="flex justify-between items-center p-4 flex-row w-full max-w-7xl">
-        <div className="text-xs md:text-lg">
-          <p>Burger menu</p>
-        </div>
+        <Sidebar
+          pages={[
+            { name: 'Home', path: '/' },
+            { name: 'Suppliers', path: '/suppliers' },
+            { name: 'Products', path: '/products' },
+            { name: 'Branches', path: '/branches' },
+          ]}
+        />
         <div className="text-sm md:text-2xl">
           <p>NaturalFoods</p>
         </div>

--- a/frontend/src/components/Sidebar/Sidebar.stories.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,0 +1,54 @@
+import { Meta, StoryObj } from '@storybook/react/*';
+import { MemoryRouter } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+
+type Story = StoryObj<typeof meta>;
+
+const meta = {
+  title: 'Sidebar',
+  component: Sidebar,
+  tags: ['autodocs'],
+  render: (args) => (
+    <MemoryRouter>
+      <Sidebar {...args} />
+    </MemoryRouter>
+  ),
+} satisfies Meta<typeof Sidebar>;
+
+export default meta;
+
+export const Default: Story = {
+  args: {
+    pages: [
+      { name: 'Home', path: '/' },
+      { name: 'Suppliers', path: '/suppliers' },
+      { name: 'Products', path: '/products' },
+      { name: 'Branches', path: '/branches' },
+    ],
+  },
+};
+
+export const EmptySidebar: Story = {
+  args: {
+    pages: [],
+  },
+};
+
+export const SinglePage: Story = {
+  args: {
+    pages: [{ name: 'Home', path: '/' }],
+  },
+};
+
+export const ManyPages: Story = {
+  args: {
+    pages: [
+      { name: 'Home', path: '/' },
+      { name: 'Suppliers', path: '/suppliers' },
+      { name: 'Products', path: '/products' },
+      { name: 'Branches', path: '/branches' },
+      { name: 'Orders', path: '/orders' },
+      { name: 'Customers', path: '/customers' },
+    ],
+  },
+};

--- a/frontend/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, userEvent } from '@/testUtils';
+import { MemoryRouter } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+
+describe('Sidebar', () => {
+  const pages = [
+    { name: 'Home', path: '/' },
+    { name: 'Suppliers', path: '/suppliers' },
+    { name: 'Products', path: '/products' },
+    { name: 'Branches', path: '/branches' },
+  ];
+
+  test('renders sidebar with correct links', async () => {
+    render(
+      <MemoryRouter>
+        <Sidebar pages={pages} />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /toggle navigation/i }),
+    );
+
+    pages.forEach((page) => {
+      const linkElement = screen.getByText(page.name);
+      expect(linkElement).toBeInTheDocument();
+      expect(linkElement.closest('a')).toHaveAttribute('href', page.path);
+    });
+  });
+});

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,36 @@
+import { Burger, Drawer } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { Link } from 'react-router-dom';
+
+interface SidebarProps {
+  pages: { name: string; path: string }[];
+}
+
+export const Sidebar = ({ pages }: SidebarProps) => {
+  const [opened, { toggle }] = useDisclosure();
+  return (
+    <div>
+      <Burger opened={opened} onClick={toggle} aria-label="Toggle navigation" />
+      <Drawer
+        position="left"
+        size="md"
+        opened={opened}
+        onClose={toggle}
+        overlayProps={{ backgroundOpacity: 0.5, blur: 4 }}
+      >
+        <div>
+          {pages.map((page) => (
+            <Link
+              key={`menu-item-${page.name.toLowerCase()}`}
+              to={page.path}
+              onClick={toggle}
+              className="block text-xl px-4 py-2 text-gray-700 hover:bg-blue-400 rounded hover:text-white"
+            >
+              {page.name}
+            </Link>
+          ))}
+        </div>
+      </Drawer>
+    </div>
+  );
+};

--- a/frontend/src/components/Sidebar/index.ts
+++ b/frontend/src/components/Sidebar/index.ts
@@ -1,0 +1,1 @@
+export { Sidebar } from './Sidebar';

--- a/frontend/src/components/common/Heading/Heading.tsx
+++ b/frontend/src/components/common/Heading/Heading.tsx
@@ -8,7 +8,18 @@ interface HeadingProps {
   className?: string;
 }
 
+const levelStyles: Record<HeadingLevel, string> = {
+  1: 'text-4xl font-bold',
+  2: 'text-3xl font-semibold',
+  3: 'text-2xl font-semibold',
+  4: 'text-xl font-semibold',
+  5: 'text-lg font-medium',
+  6: 'text-base font-medium',
+};
+
 export const Heading = ({ level = 1, children, className }: HeadingProps) => {
   const Tag = `h${level}` as keyof JSX.IntrinsicElements;
-  return <Tag className={className}>{children}</Tag>;
+  return (
+    <Tag className={`${levelStyles[level]} ${className ?? ''}`}>{children}</Tag>
+  );
 };

--- a/frontend/src/components/common/Table/TableFilter/TableFilter.tsx
+++ b/frontend/src/components/common/Table/TableFilter/TableFilter.tsx
@@ -123,6 +123,8 @@ export const TableFilter = ({
           children={
             <FilterAndSortForm
               filterItems={filterItems}
+              sortItems={sortItems}
+              orderItems={orderItems}
               onSubmit={() => setOpened(false)}
             />
           }

--- a/frontend/src/components/common/Table/TableFilter/TableFilter.tsx
+++ b/frontend/src/components/common/Table/TableFilter/TableFilter.tsx
@@ -58,7 +58,6 @@ export const TableFilter = ({
   filterItems,
 }: TableFilterProps) => {
   const [opened, setOpened] = useState(false);
-
   return (
     <div className="flex mb-4 pb-4 border-b border-gray-[#ccc]">
       {hasStatusFilter &&
@@ -110,7 +109,12 @@ export const TableFilter = ({
         <Drawer
           opened={opened}
           setOpened={setOpened}
-          children={<FilterAndSortForm filterItems={filterItems} />}
+          children={
+            <FilterAndSortForm
+              filterItems={filterItems}
+              onSubmit={() => setOpened(false)}
+            />
+          }
         />
 
         <BasicMenu

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@mantine/core/styles.css';
+import '@mantine/charts/styles.css';
 import './index.css';
 import App from './App';
 

--- a/frontend/src/pages/HomePage/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage/HomePage.test.tsx
@@ -13,14 +13,18 @@ describe('HomePage.tsx', () => {
         <HomePage />
       </MemoryRouter>,
     );
-    const headerText = screen.getByText('Awards & Accomplishments');
-    const branchLink = screen.getByText('Find a branch');
-    const produceLink = screen.getByText('View all products');
-    const supplerLink = screen.getByText('Discover our suppliers');
+    const heading = screen.getByRole('heading', {
+      name: /Welcome back Rivera!/i,
+    });
+    const revenueText = screen.getByText(/Total Revenue/i);
+    const customersText = screen.getByText(/Total Customers/i);
+    const transactionsText = screen.getByText(/Total Transactions/i);
+    const productsText = screen.getByText(/Total Products/i);
 
-    expect(headerText).toBeInTheDocument();
-    expect(produceLink).toBeInTheDocument();
-    expect(branchLink).toBeInTheDocument();
-    expect(supplerLink).toBeInTheDocument();
+    expect(revenueText).toBeInTheDocument();
+    expect(customersText).toBeInTheDocument();
+    expect(transactionsText).toBeInTheDocument();
+    expect(productsText).toBeInTheDocument();
+    expect(heading).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/HomePage/HomePage.tsx
+++ b/frontend/src/pages/HomePage/HomePage.tsx
@@ -1,81 +1,176 @@
+import Graph from '@/assets/graph.svg';
 import { Card } from '@/components/common/Card';
-import { ButtonLink } from '@/components/common/ButtonLink';
-import { Image } from '@/components/common/Image';
 import { Heading } from '@/components/common/Heading';
-import Fruits from '@/assets/FruitsAndVeg.jpg';
-import Branch from '@/assets/icons/Branches.png';
-import FreshProduce from '@/assets/icons/FreshProduce.png';
-import SupplierIcon from '@/assets/icons/Suppliers.png';
+import { Image } from '@/components/common/Image';
+import { Table } from '@/components/common/Table/Table';
+import { LineChart } from '@mantine/charts';
+import { RingProgress, Text } from '@mantine/core';
+import { Link } from 'react-router-dom';
+
+const transactions = [
+  {
+    TransactionID: '123456789',
+    ProductName: 'Apple',
+    Customer: 'John Doe',
+    Amount: '$12.99',
+    Status: 'Completed',
+    Date: '2024-06-15',
+  },
+  {
+    TransactionID: '987654321',
+    ProductName: 'Banana',
+    Customer: 'Jane Smith',
+    Amount: '$8.49',
+    Status: 'Pending',
+    Date: '2024-06-14',
+  },
+  {
+    TransactionID: '456789123',
+    ProductName: 'Carrot',
+    Customer: 'Alice Johnson',
+    Amount: '$5.75',
+    Status: 'Completed',
+    Date: '2024-06-13',
+  },
+];
+const lineGraphData = [
+  { date: 'Jan', temperature: -25 },
+  { date: 'Feb', temperature: -10 },
+  { date: 'Mar', temperature: 5 },
+  { date: 'Apr', temperature: 15 },
+  { date: 'May', temperature: 30 },
+  { date: 'Jun', temperature: 15 },
+  { date: 'Jul', temperature: 30 },
+  { date: 'Aug', temperature: 40 },
+  { date: 'Sep', temperature: 15 },
+  { date: 'Oct', temperature: 20 },
+  { date: 'Nov', temperature: 0 },
+  { date: 'Dec', temperature: -10 },
+];
 
 export const HomePage = () => {
   return (
-    <div className="flex flex-col gap-4 mt-7">
-      <p>Home</p>
-      <Card borderColor="green">
-        <div className="justify-center mb-6">
-          <Heading
-            level={1}
-            className="text-3xl mt-4 mb-6 underline underline-offset-8 text-[#2d5016] font-semibold"
-          >
-            Awards & Accomplishments
-          </Heading>
-          <Image src={Fruits} alt="food bowl" className="rounded-lg" />
-        </div>
-        <div>
-          <p className="mb-4">
-            At our core, we're dedicated to excellence—from the quality of our
-            ingredients to the relationships we build with our partners. We're
-            proud of the recognition we've received, as it reflects our
-            commitment to innovation, sustainability, and community. Here are
-            some of our notable achievements:
-          </p>
-          <p className="mb-4">
-            <span className="text-[#2d5016] font-medium text-lg">
-              "Best New Restaurant"
-            </span>{' '}
-            (2024): Awarded for our innovative approach to flavor and our
-            commitment to using locally-sourced ingredients.
-          </p>
+    <div className="flex flex-col gap-10 mt-7">
+      <div>
+        <Heading level={1} className="mt-4 mb-2 font-semibold">
+          Welcome back Rivera!
+        </Heading>
+        <p>Here's what's happening today</p>
+      </div>
+      <div className="flex flex-col md:flex-row gap-2">
+        <Card className="flex flex-col gap-8">
+          <div className="flex flex-row justify-between font-semibold">
+            <p className="text-xs">TOTAL REVENUE</p>
+            <span className="text-red-600">+5%</span>
+          </div>
+          <div className="flex flex-row justify-between font-bold text-2xl">
+            <p>$128,430</p>
+            <Image src={Graph} alt="graph icon" className="w-1/3 flex" />
+          </div>
+        </Card>
+        <Card className="flex flex-col gap-8">
+          <div className="flex flex-row justify-between font-semibold">
+            <p className="text-xs">TOTAL CUSTOMERS</p>
+            <span className="text-green-600">+3%</span>
+          </div>
+          <div className="flex flex-row justify-between font-bold text-2xl">
+            <p>14,280</p>
+            <Image src={Graph} alt="graph icon" className="w-1/3 flex" />
+          </div>
+        </Card>
+        <Card className="flex flex-col gap-8">
+          <div className="flex flex-row justify-between font-semibold">
+            <p className="text-xs">TOTAL TRANSACTIONS</p>
+            <span className="text-yellow-600">+2%</span>
+          </div>
+          <div className="flex flex-row justify-between font-bold text-2xl">
+            <p>3842</p>
+            <Image src={Graph} alt="graph icon" className="w-1/3 flex" />
+          </div>
+        </Card>
+        <Card className="flex flex-col gap-8">
+          <div className="flex flex-row justify-between font-semibold">
+            <p className="text-xs">TOTAL PRODUCTS</p>
+            <span className="text-blue-600">+8%</span>
+          </div>
+          <div className="flex flex-row justify-between font-bold text-2xl">
+            <p>1154</p>
+            <Image src={Graph} alt="graph icon" className="w-1/3 flex" />
+          </div>
+        </Card>
+      </div>
 
-          <p className="mb-4">
-            <span className="text-[#2d5016] font-medium text-lg">
-              "Sustainable Supplier of the Year"
-            </span>{' '}
-            (2023): Acknowledged for our strong partnerships with eco-friendly
-            and ethical food suppliers, a testament to our focus on responsible
-            business practices.
-          </p>
-        </div>
-      </Card>
-      <div className="flex flex-col gap-6 md:flex-row md:gap-4">
-        <Card className="flex flex-col gap-6 items-center">
-          <Image src={Branch} alt="branch icon" className="w-1/3 flex" />
-          <p>
-            Find a store near you and learn more about our local teams and
-            offerings.
-          </p>
-          <ButtonLink to="/branches">Find a branch</ButtonLink>
-        </Card>
-        <Card className="flex flex-col gap-6 items-center">
-          <Image src={FreshProduce} alt="produce icon" className="w-1/3 flex" />
-          <p>
-            Browse our full selection of food products, from fresh produce to
-            gourmet specialties.
-          </p>
-          <ButtonLink to="/products">View all products</ButtonLink>
-        </Card>
-        <Card className="flex flex-col gap-6 items-center">
-          <Image
-            src={SupplierIcon}
-            alt="suppliers icon"
-            className="w-1/3 flex"
+      <div className="grid md:grid-cols-3 gap-8">
+        <Card className=" lg:col-span-2 col-span-3">
+          <Heading level={5} className="text-xl mt-4 mb-2 font-semibold">
+            Temperature Overview
+          </Heading>
+          <p className="pb-4">Real time user engagement</p>
+          <LineChart
+            h={250}
+            data={lineGraphData}
+            series={[{ name: 'temperature', label: 'Avg. Temperature' }]}
+            dataKey="date"
+            type="gradient"
+            gradientStops={[
+              { offset: 0, color: 'blue.1' },
+              { offset: 20, color: 'blue.2' },
+              { offset: 40, color: 'blue.3' },
+              { offset: 60, color: 'blue.4' },
+              { offset: 80, color: 'blue.5' },
+              { offset: 100, color: 'blue.7' },
+            ]}
+            strokeWidth={5}
+            curveType="natural"
+            yAxisProps={{ domain: [-25, 40] }}
+            valueFormatter={(value) => `${value}°C`}
           />
-          <p>
-            Explore the trusted companies who provide us with the highest
-            quality ingredients.
-          </p>
-          <ButtonLink to="/suppliers">Discover our suppliers</ButtonLink>
         </Card>
+        <Card className="text-center lg:col-span-1 col-span-2 items-center flex flex-col">
+          <Heading level={5} className="mt-4 mb-2 font-semibold">
+            Statistics Revenue
+          </Heading>
+          <p className="font-thin text-sm">Monthly target achievement</p>
+
+          <RingProgress
+            size={250}
+            roundCaps
+            thickness={25}
+            transitionDuration={250}
+            sections={[{ value: 40, color: 'blue' }]}
+            label={
+              <Text c="blue" fw={700} ta="center" size="xl">
+                40%
+              </Text>
+            }
+          />
+        </Card>
+      </div>
+      <div className="flex flex-col gap-4 bg-white p-6">
+        <div className="flex flex-row justify-between items-center">
+          <Heading level={5} className="mt-4 mb-2 font-semibold">
+            History Transactions
+          </Heading>
+          <Link
+            to="/transactions"
+            className="text-[#1C2ECC] text-md font-semibold"
+          >
+            View All Activity
+          </Link>
+        </div>
+
+        <Table
+          actions={false}
+          columns={[
+            { key: 'TransactionID', label: 'Transaction ID' },
+            { key: 'ProductName', label: 'Product Name' },
+            { key: 'Customer', label: 'Customer' },
+            { key: 'Amount', label: 'Amount' },
+            { key: 'Status', label: 'Status' },
+            { key: 'Date', label: 'Date' },
+          ]}
+          rows={transactions}
+        />
       </div>
     </div>
   );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,36 +22,48 @@ export default defineConfig({
     },
   },
   test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./vitest.setup.ts'],
-    // or 'jsdom' for browser-like testing
-    exclude: [...configDefaults.exclude, 'e2e/**', '**/*.stories.*'],
-    // projects: [
-    //   {
-    //     extends: true,
-    //     plugins: [
-    //       // The plugin will run tests for the stories defined in your Storybook config
-    //       // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-    //       storybookTest({
-    //         configDir: path.join(dirname, '.storybook'),
-    //       }),
-    //     ],
-    //     test: {
-    //       name: 'storybook',
-    //       browser: {
-    //         enabled: true,
-    //         headless: true,
-    //         provider: 'playwright',
-    //         instances: [
-    //           {
-    //             browser: 'chromium',
-    //           },
-    //         ],
-    //       },
-    //       setupFiles: ['.storybook/vitest.setup.ts'],
-    //     },
-    //   },
-    // ],
+    projects: [
+      {
+        resolve: {
+          alias: {
+            '@': path.resolve(__dirname, './src'),
+            '@assets': path.resolve(__dirname, './src/assets'),
+            '@components': path.resolve(__dirname, './src/components'),
+          },
+        },
+        test: {
+          name: 'unit',
+          globals: true,
+          environment: 'jsdom',
+          setupFiles: ['./vitest.setup.ts'],
+          include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+          exclude: [...configDefaults.exclude, 'e2e/**', '**/*.stories.*'],
+        },
+      },
+      {
+        extends: true,
+        plugins: [
+          // The plugin will run tests for the stories defined in your Storybook config
+          // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+          storybookTest({
+            configDir: path.join(dirname, '.storybook'),
+          }),
+        ],
+        test: {
+          name: 'storybook',
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: 'playwright',
+            instances: [
+              {
+                browser: 'chromium',
+              },
+            ],
+          },
+          setupFiles: ['.storybook/vitest.setup.ts'],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Dashboard Homepage Redesign & Test Infrastructure Improvements

### Overview
Redesigns the `HomePage` into a functional dashboard view and improves the test configuration to support separate unit and Storybook test runs.

### Changes

#### Homepage Dashboard
- Replaced the static awards/accomplishments page with a live-data dashboard layout
- Added four KPI stat cards (Total Revenue, Customers, Transactions, Products) with percentage indicators and a trend graph SVG
- Added a `LineChart` (Mantine Charts) showing a temperature overview with a blue gradient
- Added a `RingProgress` component for monthly revenue target visualisation
- Added a recent transactions table with a "View All Activity" link
- Added new `graph.svg` asset for stat card trend indicators

#### Sidebar Component
- Extracted navigation into a new reusable `Sidebar` component using Mantine `Burger` and `Drawer`
- Replaced the placeholder burger menu in `Header` with the new `Sidebar`
- Added Sidebar stories (`Default`, `EmptySidebar`, `SinglePage`, `ManyPages`) and unit tests
- Updated `Header.stories.tsx` to wrap with `MemoryRouter`

#### Heading Component
- Added default Tailwind size styles per heading level (`h1`–`h6`) so semantic level is reflected visually without requiring explicit class overrides

#### FilterAndSortForm
- Renamed `onClose` prop to `onSubmit` to decouple the form from drawer UI state, improving reusability
- Updated `TableFilter` to handle drawer closing in the parent via `onSubmit` callback
- Updated tests to assert `onSubmit` is called on form submission

#### Dependencies
- Upgraded `@mantine/core` and `@mantine/hooks` from v8 to v9
- Added `@mantine/charts` and `recharts` for chart components
- Added `@mantine/charts/styles.css` import to `main.tsx`

#### Test Configuration
- Restructured vite.config.ts to use named vitest `projects` (`unit` and `storybook`)
- Added separate npm scripts: `test` (unit only), `test:storybook` (Storybook browser tests), `test:all` (both)
- Removed `@storybook/addon-vitest` and `storybook-dark-mode` from Storybook addons to prevent test runner interference
- Fixed path alias resolution (`@/`) within the unit test project config


<img width="1098" height="859" alt="Screenshot 2026-05-13 at 3 44 07 pm" src="https://github.com/user-attachments/assets/4ec5fbb5-80ea-4215-8da1-88b15e4f146f" />