### PR TITLE
Add csv excel pdf file download

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,11 +21,14 @@
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-query-devtools": "^5.91.2",
     "axios": "^1.11.0",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.8",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-hook-form": "^7.71.1",
     "react-router-dom": "^7.8.1",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.1",

--- a/frontend/src/components/common/Table/TableFilter/TableFilter.test.tsx
+++ b/frontend/src/components/common/Table/TableFilter/TableFilter.test.tsx
@@ -6,10 +6,12 @@ import { MemoryRouter } from 'react-router-dom';
 
 describe('TableFilter Component', () => {
   const mockSetFilterStatus = vi.fn();
+  const mockOnExport = vi.fn();
   const filterItems = ['View', 'Edit', 'Delete'];
 
   beforeEach(() => {
     mockSetFilterStatus.mockClear();
+    mockOnExport.mockClear();
   });
 
   it('renders filter buttons correctly on desktop', () => {
@@ -114,7 +116,30 @@ describe('TableFilter Component', () => {
     });
   });
 
-  it('renders filter and sort button and export button', () => {
+  it('renders filter and sort button and export button when onExport is provided', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    render(
+      <MemoryRouter>
+        <TableFilter
+          hasStatusFilter={false}
+          filterItems={filterItems}
+          onExport={mockOnExport}
+        />
+      </MemoryRouter>,
+    );
+
+    const filterButton = screen.getByText(/filter & sort/i);
+    const exportButton = screen.getByText(/export/i);
+
+    expect(filterButton).toBeInTheDocument();
+    expect(exportButton).toBeInTheDocument();
+  });
+
+  it('does not render export button when onExport is not provided', () => {
     Object.defineProperty(window, 'innerWidth', {
       writable: true,
       configurable: true,
@@ -126,10 +151,57 @@ describe('TableFilter Component', () => {
       </MemoryRouter>,
     );
 
-    const filterButton = screen.getByText(/filter & sort/i);
-    const exportButton = screen.getByText(/export/i);
+    expect(screen.queryByText(/export/i)).not.toBeInTheDocument();
+  });
 
-    expect(filterButton).toBeInTheDocument();
-    expect(exportButton).toBeInTheDocument();
+  it('calls onExport with csv format', async () => {
+    render(
+      <MemoryRouter>
+        <TableFilter
+          hasStatusFilter={false}
+          filterItems={filterItems}
+          onExport={mockOnExport}
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByText(/export/i));
+    await userEvent.click(screen.getByText('CSV'));
+
+    expect(mockOnExport).toHaveBeenCalledWith('csv');
+  });
+
+  it('calls onExport with excel format', async () => {
+    render(
+      <MemoryRouter>
+        <TableFilter
+          hasStatusFilter={false}
+          filterItems={filterItems}
+          onExport={mockOnExport}
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByText(/export/i));
+    await userEvent.click(screen.getByText('Excel'));
+
+    expect(mockOnExport).toHaveBeenCalledWith('excel');
+  });
+
+  it('calls onExport with pdf format', async () => {
+    render(
+      <MemoryRouter>
+        <TableFilter
+          hasStatusFilter={false}
+          filterItems={filterItems}
+          onExport={mockOnExport}
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByText(/export/i));
+    await userEvent.click(screen.getByText('PDF'));
+
+    expect(mockOnExport).toHaveBeenCalledWith('pdf');
   });
 });

--- a/frontend/src/components/common/Table/TableFilter/TableFilter.tsx
+++ b/frontend/src/components/common/Table/TableFilter/TableFilter.tsx
@@ -8,31 +8,28 @@ import { Drawer } from '../../Drawer';
 import { FilterAndSortForm } from '../../../Forms/FilterAndSortForm';
 import { Image } from '../../Image/Image';
 
-interface TablePropsWithFilter {
+type ExportFormat = 'csv' | 'excel' | 'pdf';
+
+interface TableFilterBaseProps {
+  filterItems: string[];
+  sortItems?: string[];
+  orderItems?: { label: string; value: string }[];
+  onExport?: (format: ExportFormat) => void;
+}
+
+interface TablePropsWithFilter extends TableFilterBaseProps {
   hasStatusFilter: true;
   filteredStatus: string;
   setFilterStatus: (value: string) => void;
-  filterItems: string[];
-  sortItems?: string[];
-  orderItems?: { label: string; value: string }[];
 }
 
-interface TablePropsWithNoFilter {
+interface TablePropsWithNoFilter extends TableFilterBaseProps {
   hasStatusFilter: false;
   filteredStatus?: never;
   setFilterStatus?: never;
-  filterItems: string[];
-  sortItems?: string[];
-  orderItems?: { label: string; value: string }[];
 }
 
 type TableFilterProps = TablePropsWithFilter | TablePropsWithNoFilter;
-
-const exportMenuItems = [
-  { label: 'CSV' },
-  { label: 'Excel' },
-  { label: 'PDF' },
-];
 
 const StatusButton = ({
   status,
@@ -62,8 +59,15 @@ export const TableFilter = ({
   filterItems,
   sortItems,
   orderItems,
+  onExport,
 }: TableFilterProps) => {
   const [opened, setOpened] = useState(false);
+  const exportMenuItems = [
+    { label: 'CSV', onClick: () => onExport?.('csv') },
+    { label: 'Excel', onClick: () => onExport?.('excel') },
+    { label: 'PDF', onClick: () => onExport?.('pdf') },
+  ];
+
   return (
     <div className="flex mb-4 pb-4 border-b border-gray-[#ccc]">
       {hasStatusFilter &&
@@ -130,17 +134,19 @@ export const TableFilter = ({
           }
         />
 
-        <BasicMenu
-          target={
-            <button className="border border-[#bcbcbc] rounded-[8px] px-3 py-1.5">
-              <div className="flex items-center gap-1.5">
-                <Image src={Export} alt="export icon" className="w-[15px]" />
-                <p className="hidden md:block">Export</p>
-              </div>
-            </button>
-          }
-          items={exportMenuItems}
-        />
+        {onExport && (
+          <BasicMenu
+            target={
+              <button className="border border-[#bcbcbc] rounded-[8px] px-3 py-1.5">
+                <div className="flex items-center gap-1.5">
+                  <Image src={Export} alt="export icon" className="w-[15px]" />
+                  <p className="hidden md:block">Export</p>
+                </div>
+              </button>
+            }
+            items={exportMenuItems}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/BranchSearch/BranchSearch.tsx
+++ b/frontend/src/pages/BranchSearch/BranchSearch.tsx
@@ -8,6 +8,7 @@ import { TableFilter } from '@/components/common/Table/TableFilter';
 import { useSearchBranches } from '@/services/Branches/Branches';
 import { Loader } from '@mantine/core';
 import { Pagination } from '@/components/common/Pagination';
+import { handleTableExport } from '@/utils';
 
 export const BranchSearch = () => {
   const [paginationPage, setPaginationPage] = useState(1);
@@ -45,6 +46,21 @@ export const BranchSearch = () => {
     searchParams[1](`branchName=${searchText}&page=${page}`);
   };
 
+  const tableColumns = [
+    { key: 'branchName', label: 'Branch Name' },
+    { key: 'branchEmail', label: 'Branch Email' },
+    { key: 'phoneNumber', label: 'Branch Phone' },
+    { key: 'address', label: 'Address' },
+    { key: 'yearsActive', label: 'Years Active' },
+    { key: 'suppliers', label: 'Suppliers' },
+  ];
+
+  const tableRows = (branches?.data ?? []) as Record<string, unknown>[];
+
+  const handleExport = (format: 'csv' | 'excel' | 'pdf') => {
+    handleTableExport(format, tableColumns, tableRows, 'branches-export');
+  };
+
   return (
     <div className="flex flex-col gap-6">
       <SearchBar
@@ -74,20 +90,10 @@ export const BranchSearch = () => {
               { label: 'Newest', value: 'newest' },
               { label: 'Oldest', value: 'oldest' },
             ]}
+            onExport={handleExport}
           />
           <div className="flex flex-col gap-4 justify-center items-center w-full bg-white p-5 border border-gray-300 rounded-md shadow-sm">
-            <Table
-              actions={true}
-              columns={[
-                { key: 'branchName', label: 'Branch Name' },
-                { key: 'branchEmail', label: 'Branch Email' },
-                { key: 'phoneNumber', label: 'Branch Phone' },
-                { key: 'address', label: 'Address' },
-                { key: 'yearsActive', label: 'Years Active' },
-                { key: 'suppliers', label: 'Suppliers' },
-              ]}
-              rows={branches?.data ?? []}
-            />
+            <Table actions={true} columns={tableColumns} rows={tableRows} />
             <Pagination
               setCurrentPage={handleSetPaginationPage}
               currentPage={branches?.currentPage ?? paginationPage}

--- a/frontend/src/pages/ProductSearch/ProductSearch.tsx
+++ b/frontend/src/pages/ProductSearch/ProductSearch.tsx
@@ -8,6 +8,7 @@ import { TableFilter } from '@/components/common/Table/TableFilter';
 import { useSearchProducts } from '@/services/Products/Products';
 import { Loader } from '@mantine/core';
 import { Pagination } from '@/components/common/Pagination';
+import { handleTableExport } from '@/utils';
 
 export const ProductSearch = () => {
   const [paginationPage, setPaginationPage] = useState(1);
@@ -45,6 +46,19 @@ export const ProductSearch = () => {
     searchParams[1](`productName=${searchText}&page=${page}`);
   };
 
+  const tableColumns = [
+    { key: 'name', label: 'Product Name' },
+    { key: 'category', label: 'Category' },
+    { key: 'supplier', label: 'Supplier' },
+    { key: 'price', label: 'Price' },
+  ];
+
+  const tableRows = (products?.data ?? []) as Record<string, unknown>[];
+
+  const handleExport = (format: 'csv' | 'excel' | 'pdf') => {
+    handleTableExport(format, tableColumns, tableRows, 'products-export');
+  };
+
   return (
     <div className="flex flex-col gap-6">
       <SearchBar
@@ -67,23 +81,15 @@ export const ProductSearch = () => {
           <TableFilter
             hasStatusFilter={false}
             filterItems={['Barcode', 'Category', 'Supplier']}
-            sortItems={['Supplier','Price','Category']}
+            sortItems={['Supplier', 'Price', 'Category']}
             orderItems={[
               { label: 'Ascending', value: 'asc' },
               { label: 'Descending', value: 'desc' },
             ]}
+            onExport={handleExport}
           />
           <div className="flex flex-col gap-4 justify-center items-center w-full bg-white p-5 border border-gray-300 rounded-md shadow-sm">
-            <Table
-              actions={true}
-              columns={[
-                { key: 'name', label: 'Product Name' },
-                { key: 'category', label: 'Category' },
-                { key: 'supplier', label: 'Supplier' },
-                { key: 'price', label: 'Price' },
-              ]}
-              rows={products?.data ?? []}
-            />
+            <Table actions={true} columns={tableColumns} rows={tableRows} />
             <Pagination
               setCurrentPage={handleSetPaginationPage}
               currentPage={products?.currentPage ?? paginationPage}

--- a/frontend/src/pages/SuppliersSearch/SupplierSearch.tsx
+++ b/frontend/src/pages/SuppliersSearch/SupplierSearch.tsx
@@ -8,6 +8,7 @@ import { TableFilter } from '@/components/common/Table/TableFilter';
 import { Loader } from '@mantine/core';
 import { Pagination } from '@/components/common/Pagination';
 import { useSearchSuppliers } from '@/services/Suppliers/Supplier';
+import { handleTableExport } from '@/utils';
 
 export const SupplierSearch = () => {
   const [paginationPage, setPaginationPage] = useState(1);
@@ -52,6 +53,20 @@ export const SupplierSearch = () => {
     searchParams[1](`companyName=${searchText}${statusQuery}&page=${page}`);
   };
 
+  const tableColumns = [
+    { key: 'companyName', label: 'Company Name' },
+    { key: 'status', label: 'Status' },
+    { key: 'email', label: 'Company Email' },
+    { key: 'phoneNumber', label: 'Company Phone' },
+    { key: 'products', label: 'Products' },
+  ];
+
+  const tableRows = (suppliers?.data ?? []) as Record<string, unknown>[];
+
+  const handleExport = (format: 'csv' | 'excel' | 'pdf') => {
+    handleTableExport(format, tableColumns, tableRows, 'suppliers-export');
+  };
+
   return (
     <div className="flex flex-col gap-6">
       <SearchBar
@@ -81,19 +96,10 @@ export const SupplierSearch = () => {
             ]}
             filteredStatus={filterStatus}
             setFilterStatus={handleSetFilterStatus}
+            onExport={handleExport}
           />
           <div className="flex flex-col gap-4 justify-center items-center w-full bg-white p-5 border border-gray-300 rounded-md shadow-sm">
-            <Table
-              actions={true}
-              columns={[
-                { key: 'companyName', label: 'Company Name' },
-                { key: 'status', label: 'Status' },
-                { key: 'email', label: 'Company Email' },
-                { key: 'phoneNumber', label: 'Company Phone' },
-                { key: 'products', label: 'Products' },
-              ]}
-              rows={suppliers?.data ?? []}
-            />
+            <Table actions={true} columns={tableColumns} rows={tableRows} />
             <Pagination
               setCurrentPage={handleSetPaginationPage}
               currentPage={suppliers?.currentPage ?? paginationPage}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -3,3 +3,11 @@ export { camelToFlat } from './camelToFlat';
 export { toCamelCase } from './toCamelCase';
 export { formatHeader } from './formatHeader';
 export { getPaginationItems } from './getPaginationItems';
+export {
+  exportToCsv,
+  exportToExcel,
+  exportToPdf,
+  handleTableExport,
+  type ExportFormat,
+  type ExportColumn,
+} from './tableExport';

--- a/frontend/src/utils/tableExport.test.ts
+++ b/frontend/src/utils/tableExport.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import autoTable from 'jspdf-autotable';
+import { handleTableExport, ExportColumn } from './tableExport';
+
+vi.mock('jspdf-autotable', () => ({
+  default: vi.fn(),
+}));
+
+describe('handleTableExport', () => {
+  const mockColumns: ExportColumn[] = [
+    { key: 'name', label: 'Name' },
+    { key: 'email', label: 'Email' },
+  ];
+
+  const mockRows = [
+    { name: 'John Doe', email: 'john@example.com' },
+    { name: 'Jane Smith', email: 'jane@example.com' },
+  ];
+
+  const fileName = 'test-export';
+  const createObjectURLMock = vi.fn(() => 'blob:mock-url');
+  const revokeObjectURLMock = vi.fn();
+  const originalCreateElement = document.createElement.bind(document);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: createObjectURLMock,
+    });
+
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: revokeObjectURLMock,
+    });
+  });
+
+  it('should call exportToCsv when format is csv', () => {
+    const anchor = originalCreateElement('a');
+    const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+      if (tagName === 'a') {
+        return anchor;
+      }
+
+      return originalCreateElement(tagName);
+    });
+
+    handleTableExport('csv', mockColumns, mockRows, fileName);
+
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    expect(anchor.download).toBe(`${fileName}.csv`);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call exportToExcel when format is excel', () => {
+    const anchor = originalCreateElement('a');
+    const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+      if (tagName === 'a') {
+        return anchor;
+      }
+
+      return originalCreateElement(tagName);
+    });
+
+    handleTableExport('excel', mockColumns, mockRows, fileName);
+
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    expect(anchor.download).toBe(`${fileName}.xlsx`);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call exportToPdf when format is pdf', () => {
+    handleTableExport('pdf', mockColumns, mockRows, fileName);
+
+    expect(autoTable).toHaveBeenCalledTimes(1);
+    expect(createObjectURLMock).not.toHaveBeenCalled();
+  });
+
+  it('should pass correct parameters with custom fileName', () => {
+    const anchor = originalCreateElement('a');
+    vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+      if (tagName === 'a') {
+        return anchor;
+      }
+
+      return originalCreateElement(tagName);
+    });
+
+    const customFileName = 'custom-export-name';
+
+    handleTableExport('csv', mockColumns, mockRows, customFileName);
+
+    expect(anchor.download).toBe(`${customFileName}.csv`);
+  });
+
+  it('should handle empty rows array', () => {
+    const anchor = originalCreateElement('a');
+    vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+      if (tagName === 'a') {
+        return anchor;
+      }
+
+      return originalCreateElement(tagName);
+    });
+
+    const emptyRows: typeof mockRows = [];
+
+    handleTableExport('excel', mockColumns, emptyRows, fileName);
+
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    expect(anchor.download).toBe(`${fileName}.xlsx`);
+  });
+});

--- a/frontend/src/utils/tableExport.ts
+++ b/frontend/src/utils/tableExport.ts
@@ -1,0 +1,172 @@
+import * as XLSX from 'xlsx';
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+
+export type ExportFormat = 'csv' | 'excel' | 'pdf';
+
+export interface ExportColumn {
+  key: string;
+  label: string;
+}
+
+const normalizeCellValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry)).join(', ');
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+};
+
+const downloadBlob = (blob: Blob, fileName: string) => {
+  const link = document.createElement('a');
+  const objectUrl = URL.createObjectURL(blob);
+
+  link.href = objectUrl;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(objectUrl);
+};
+
+const escapeCsvCell = (value: string): string => {
+  const escapedValue = value.replace(/"/g, '""');
+  return `"${escapedValue}"`;
+};
+
+export const exportToCsv = (
+  columns: ExportColumn[],
+  rows: Record<string, unknown>[],
+  fileName: string,
+) => {
+  const header = columns.map((column) => escapeCsvCell(column.label)).join(',');
+  const body = rows.map((row) => {
+    return columns
+      .map((column) => normalizeCellValue(row[column.key]))
+      .map((value) => escapeCsvCell(value))
+      .join(',');
+  });
+
+  const csv = [header, ...body].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+
+  downloadBlob(blob, `${fileName}.csv`);
+};
+
+export const exportToExcel = (
+  columns: ExportColumn[],
+  rows: Record<string, unknown>[],
+  fileName: string,
+) => {
+  const worksheetData = [
+    columns.map((column) => column.label),
+    ...rows.map((row) =>
+      columns.map((column) => normalizeCellValue(row[column.key])),
+    ),
+  ];
+
+  const worksheet = XLSX.utils.aoa_to_sheet(worksheetData);
+
+  // Auto-fit column widths based on content
+  const colWidths = columns.map((column) => {
+    const headerWidth = column.label.length;
+    const maxRowWidth = Math.max(
+      ...rows.map((row) => normalizeCellValue(row[column.key]).length),
+    );
+    const width = Math.max(headerWidth, maxRowWidth) + 2; // Add padding
+    return { wch: Math.min(width, 50) }; // Cap at 50 to avoid extremely wide columns
+  });
+
+  worksheet['!cols'] = colWidths;
+
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Export');
+
+  const excelBuffer = XLSX.write(workbook, { bookType: 'xlsx', type: 'array' });
+  const blob = new Blob([excelBuffer], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+
+  downloadBlob(blob, `${fileName}.xlsx`);
+};
+
+export const exportToPdf = (
+  columns: ExportColumn[],
+  rows: Record<string, unknown>[],
+  fileName: string,
+) => {
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
+
+  // Add title
+  doc.setFontSize(14);
+  doc.text(fileName, 14, 15);
+
+  // Prepare table data
+  const tableBody = rows.map((row) =>
+    columns.map((column) => normalizeCellValue(row[column.key])),
+  );
+
+  // Generate table using autoTable
+  autoTable(doc, {
+    head: [columns.map((column) => column.label)],
+    body: tableBody,
+    startY: 22,
+    theme: 'grid',
+    styles: {
+      font: 'helvetica',
+      fontSize: 10,
+      cellPadding: 3,
+    },
+    headStyles: {
+      fillColor: [60, 76, 227], // #3C4CE3 from your design
+      textColor: 255,
+      fontStyle: 'bold',
+      halign: 'center',
+    },
+    alternateRowStyles: {
+      fillColor: [240, 240, 240],
+    },
+    columnStyles: {},
+    margin: { left: 14, right: 14, top: 22, bottom: 14 },
+    didDrawPage: () => {
+      doc.setFontSize(8);
+      const pageCount = doc.internal.pages.length;
+      doc.text(
+        `Page ${pageCount}`,
+        doc.internal.pageSize.getWidth() / 2,
+        doc.internal.pageSize.getHeight() - 7,
+        { align: 'center' },
+      );
+    },
+  });
+
+  doc.save(`${fileName}.pdf`);
+};
+
+export const handleTableExport = (
+  format: ExportFormat,
+  columns: ExportColumn[],
+  rows: Record<string, unknown>[],
+  fileName: string,
+) => {
+  if (format === 'csv') {
+    exportToCsv(columns, rows, fileName);
+    return;
+  }
+
+  if (format === 'excel') {
+    exportToExcel(columns, rows, fileName);
+    return;
+  }
+
+  exportToPdf(columns, rows, fileName);
+};

--- a/frontend/src/utils/tableExport.ts
+++ b/frontend/src/utils/tableExport.ts
@@ -49,12 +49,11 @@ export const exportToCsv = (
   fileName: string,
 ) => {
   const header = columns.map((column) => escapeCsvCell(column.label)).join(',');
-  const body = rows.map((row) => {
-    return columns
-      .map((column) => normalizeCellValue(row[column.key]))
-      .map((value) => escapeCsvCell(value))
-      .join(',');
-  });
+  const body = rows.map((row) =>
+    columns
+      .map((col) => escapeCsvCell(normalizeCellValue(row[col.key])))
+      .join(','),
+  );
 
   const csv = [header, ...body].join('\n');
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });


### PR DESCRIPTION
## PR Title
Refactor table export flow, improve CSV/Excel/PDF output, and add export test coverage

## PR Description
### Summary
This PR improves table export behavior across search pages and centralizes export logic into a reusable utility. It also updates `TableFilter` export behavior to be optional, enhances Excel/PDF formatting, and adds unit tests for export routing.

### What Changed
- Added a reusable export utility in tableExport.ts:
  - `exportToCsv`
  - `exportToExcel` with content-based auto-fit column widths
  - `exportToPdf` using `jspdf-autotable` for structured table output
  - `handleTableExport` to route by format (`csv | excel | pdf`)
- Exported new helpers via index.ts.
- Updated TableFilter.tsx:
  - Added optional `onExport` prop
  - Shows export menu only when `onExport` is provided
  - Wires CSV/Excel/PDF menu actions to callback
- Updated `TableFilter` tests in TableFilter.test.tsx:
  - Verifies export button visibility behavior
  - Verifies `onExport` is called with correct format
- Refactored pages to use shared export handler:
  - BranchSearch.tsx
  - ProductSearch.tsx
  - SupplierSearch.tsx
- Added export utility tests in tableExport.test.ts:
  - CSV path behavior
  - Excel path behavior
  - PDF path behavior
  - filename/empty-row edge checks
- Added frontend dependencies in package.json:
  - `jspdf`
  - `jspdf-autotable`
  - `xlsx`

### Why
- Removes duplicated export logic across three pages.
- Prevents export UI from rendering when export callback is not supplied.
- Produces more usable export files:
  - Excel columns are no longer cramped
  - PDF output is tabular and readable (not plain text dump)

### Testing
- Updated and added unit tests for:
  - `TableFilter` export interactions
  - `handleTableExport` routing/behavior
- Suggested verification commands:
  - `npm test`
  - `npm run build`

### Notes for Reviewers
- There is a generated artifact file in the branch: frontend/test-export.pdf.  
  It appears to be a local export output and not app/runtime code. Recommend removing it before merge if not intentionally tracked.